### PR TITLE
feat: add optional configurable IP addresses via overrides.json

### DIFF
--- a/OVERRIDES.md
+++ b/OVERRIDES.md
@@ -1,0 +1,55 @@
+# Overrides Guide
+
+Dropship supports configurable server IP addresses via `overrides.json` - no recompilation needed!
+
+## How It Works
+
+Create **optional** `overrides.json` next to `dropship.exe` to override built-in IP addresses. Only include entries you want to customize - everything else uses hardcoded defaults.
+
+## Example: Override Brazil Server
+
+Create `overrides.json`:
+
+```json
+{
+  "servers": {
+    "google/southamerica-east1": {
+      "block": "34.39.128.0/17,34.95.128.0/17,34.104.80.0/21,34.124.16.0/21,34.151.0.0/18,34.151.192.0/18,35.198.0.0/18,35.199.64.0/18,35.215.192.0/18,35.220.40.0/24,35.235.0.0/20,35.242.40.0/24,35.247.192.0/18,2600:1900:40f0::/44,2600:1902:200::/44"
+    }
+  },
+  "endpoints": {
+    "Brazil": {
+      "description": "GBR1",
+      "ip_ping": "34.39.128.0",
+      "blocked_servers": ["google/southamerica-east1"]
+    }
+  }
+}
+```
+
+Save and restart Dropship. All other regions use built-in defaults.
+
+## Available Server IDs
+
+- `blizzard/ord1` - USA Central
+- `blizzard/las1` - USA West  
+- `google/europe-north1` - Finland
+- `google/asia-southeast1` - Singapore
+- `google/southamerica-east1` - Brazil
+- `google/asia-northeast1` - Tokyo
+- `google/me-central2` - Saudi Arabia
+- `blizzard/icn1` - South Korea
+- `blizzard/syd2` - Australia
+- `blizzard/tpe1` - Taiwan
+- `blizzard/ams1` - Netherlands
+
+## Adding New Regions
+
+Add entries to both `servers` and `endpoints` sections with matching IDs, then restart.
+
+## Notes
+
+- **Optional**: No overrides.json needed - app works with built-in defaults
+- **Override**: Only entries in overrides.json replace defaults
+- **Fallback**: Invalid JSON? App uses built-in defaults automatically
+- **CIDR Format**: Use comma-separated CIDR ranges (e.g., `10.0.0.0/8,192.168.0.0/16`)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ does this app support `tunneling`? | yes, `tunneling` is enabled by default and 
 what is `tunneling`? | `tunneling` makes sure servers are blocked per-application instead of globally. `tunneling` prevents servers in other games and apps from becoming unintentionally blocked
 how do i pin this app to my taskbar? | <img src="https://github.com/user-attachments/assets/a0cf3cf5-4b24-4ee5-b893-b95a73b9e75b" height="90" />
 does this app modify the game? | this app does **_not_** modify the game in any way. instead, this app works by adding windows firewall rules that block certain servers just like an ad blocker would
+can i customize server IPs? | yes! edit `overrides.json` next to the exe - see [OVERRIDES.md](OVERRIDES.md) for details
 
 <!--   - if you ever get disconnected this means the OW2 servers were changed and i need to update the app - please let me know through [discord](https://discord.stormy.gg/) or [twitter](https://twitter.stormy.gg/) so i can fix it -->
 

--- a/dropship/dropship/src/core/Settings.h
+++ b/dropship/dropship/src/core/Settings.h
@@ -15,13 +15,13 @@ using json = nlohmann::json;
 namespace dropship::settings {
 
     struct unique_server {
-        const std::string block;
+        std::string block;
     };
 
 
     struct unique_endpoint {
-        const std::string description;
-        const std::string ip_ping { "" };
+        std::string description;
+        std::string ip_ping { "" };
         std::set<std::string> blocked_servers;
         
     };
@@ -78,7 +78,7 @@ class Settings
     /* consts */
     private:
 
-        const std::map<std::string, dropship::settings::unique_server> __ow2_servers {
+        std::map<std::string, dropship::settings::unique_server> __ow2_servers {
 
             // { "test", { .block = "" }}, // PEERINGDB
 
@@ -143,7 +143,7 @@ class Settings
 
         };
 
-        const std::map<std::string, dropship::settings::unique_endpoint> __ow2_endpoints {
+        std::map<std::string, dropship::settings::unique_endpoint> __ow2_endpoints {
 
             /*{ " .test", {
                 .description = "test",
@@ -249,6 +249,8 @@ class Settings
 
         [[nodiscard]] std::optional<json> readStoragePatch__win_firewall();
         [[nodiscard]] std::optional<json> readStoragePatch();
+
+        void loadServerEndpointConfig();
 
         [[nodiscard]] std::string getAllBlockedAddresses();
 


### PR DESCRIPTION
### Summary 
Adds ability to override server IP addresses via optional `overrides.json` file, without waiting for app updates or recompiling from source.

### Changes
- Added `loadServerEndpointConfig()` method in `Settings` class to parse JSON overrides
- Created `OVERRIDES.md` with comprehensive documentation and examples
- Updated FAQ in `README.md` with link to configuration guide (`OVERRIDES.md`)

### Key Features
- **Optional**: App works with built-in defaults if `overrides.json` is missing
- **Partial override**: Only entries in `overrides.json` replace defaults
- **Add new regions**: Supports both overriding existing entries and adding new regions
- **Graceful fallback**: Invalid JSON automatically falls back to hardcoded values